### PR TITLE
TLK-1216: implement bull rebirth in incubator

### DIFF
--- a/docs/tlk-1216-bull-rebirth-ui-handoff.md
+++ b/docs/tlk-1216-bull-rebirth-ui-handoff.md
@@ -1,0 +1,181 @@
+# TLK-1216 Bull Rebirth UI Handoff
+
+## Deployment
+
+Testnet deployment completed on 2026-04-22.
+
+- Shared oracle data `jsonData/oracle-dev.json`: `7SpRBRW1MxWXVwxBoSNzL8agEnL2J9gkuJpTan9qM1Bq`
+- Bull oracle data `ride/bulls/oracle-dev.json`: `G4Kbg9xsR79ytgx815E65xLEErF8Veynm3gxetzRviyF`
+- Bull breeder script: `44KMo6YCpvr9Es3hbKKxQeN2BPYWguaPZqKP2Z9P2J8s`
+- Bull farming script: `Hn2yW8FVPJab66MGXwRajEN8wox4Ka4BkL4yahgeWyqA`
+- Baby ducks script: `54AP67Jx1tMU2Uk5CJKqYt2xXwCW6sWZfAgsTXMEJ34w`
+- Items script: `igLUguR1ZQhB6s1DFwjZX8VXnud4nE1TiTinqgRXiZW`
+- Bull incubator/rebirth script: `EKarB7aijCp2xosoBwbnfciheVUkDA6WKPncSoJGMuyY`
+- Bull incubator/rebirth script with `finishRebirthItem` / `finishRebirthDouble` support: `HiECYaU1RhaRqodRXu4KLUL6uskHDdHCE2qihjZCe1me`
+
+## Testnet Addresses
+
+- Shared oracle: `3MxZNnLG9EBcb4yExxNwcFq9vcyMb7DcGT9`
+- Bull incubator and rebirth dApp: `3N9osDS2cP1cT1NxJm7gb16Qusff5zHh5BF`
+- Bull breeder: `3N92kXgNnFmC8zQ4dkui6xLn6xXym1P6htV`
+- Bull farming: `3MqBeXvwb1ZEiMjG4edw6uRBBTqGbyrLsqN`
+- Items: `3N1ZfechNGoBTZyzvCAxGXPKchL4C6438dr`
+- Baby ducks: `3MpLKSQezEyHJk8jn9ikzAaaGuRzy5STBLZ`
+- TN asset: `DDbgwqvbAyiWTahPXcPECiYwAyw7wHy5FaK5Dg4PbDjN`
+
+## Oracle Keys
+
+Bull oracle keys:
+
+- `static_bullAssetId`: TN asset id.
+- `static_bullIncubatorAddress`: bull incubator and rebirth dApp address.
+- `static_bullIncubationFee`: existing hatch fee.
+- `static_bullRebirthPrice`: `99900000000`, meaning 999 TN with 8 decimals.
+- `static_bullPerchFee`: existing bull ranch/perch fee.
+- `static_bullFarmingAddress`: bull farming dApp.
+- `static_bullBreederAddress`: bull breeder dApp.
+
+Shared oracle keys used by rewards:
+
+- `static_bullIncubatorAddress`: authorizes bull rebirth calls from the incubator.
+- `static_itemsAddress`: item reward issuer.
+- `static_babyDuckAddress`: baby duck reward issuer.
+- `static_mutantFarmingAddress`: receives 1% of rebirth TN as top-up.
+- `static_feeAggregator`: receives wave extra fee and 9% of rebirth TN.
+- `static_extraFee`: required WAVES payment for every callable.
+
+There is no separate `static_bullRebirthAddress`; use `static_bullIncubatorAddress`.
+
+## UI Flow
+
+Start a rebirth with `initRebirth()` on the bull incubator/rebirth dApp.
+
+Payments, in exact order:
+
+- Payment 0: the bull NFT, amount `1`.
+- Payment 1: TN, amount from `static_bullRebirthPrice`, currently `99900000000`.
+- Payment 2: WAVES, amount from shared/bull oracle `static_extraFee`, asset id omitted or `null`.
+
+Finish a rebirth on the same dApp. The bull rebirth reuses the existing incubator contract and supports the same finish item flow as other rebirths.
+
+Normal finish:
+
+- Method: `finishRebirth(initTx: String)`
+- Payment 0: WAVES, amount from `static_extraFee`, asset id omitted or `null`.
+
+Double reward finish:
+
+- Method: `finishRebirthDouble(initTx: String)`
+- Payment 0: one `ART-GIFT_DOUBL` item NFT.
+- Payment 1: WAVES, amount from `static_extraFee`, asset id omitted or `null`.
+
+Item-assisted finish:
+
+- Method: `finishRebirthItem(initTx: String, itemCode: String)`
+- Without booster: one WAVES payment, same as normal finish.
+- With booster: Payment 0 is one booster item NFT, Payment 1 is the WAVES extra fee.
+- `ART-HWERASE`: burns the booster and blacklists `itemCode` from the reward selection.
+- `ART-HWRESCUE`: burns the booster and adds a 50% chance to return the rebirthed bull NFT, restoring its rarity/stat counters.
+- `ART-GIFT_DOUBL`: burns the booster and returns a double reward.
+
+Arguments:
+
+- `initTx`: the transaction id returned by `initRebirth`.
+- `itemCode`: only used by `ART-HWERASE`; pass the full reward code to blacklist, for example `item!ART-FEED5`, `bull_ranch_A`, `duckling_10`, or `bull_genesis`.
+
+Timing:
+
+- Rebirth uses `delayForHatching = 2`, so finish is allowed at `initHeight + 2`.
+- If called too early, the contract throws `BRF: you cannot finish rebirth yet`.
+
+## Data Keys
+
+For caller address `address` and init transaction id `initTx`:
+
+- Status: `address_${address}_initTx_${initTx}_status`
+- Finish height: `address_${address}_initTx_${initTx}_finishBlock`
+- Rebirth asset: `address_${address}_initTx_${initTx}_assetId`
+- Reward code after finish: `address_${address}_initTx_${initTx}_win`
+- Reward code for the second reward when doubled: `address_${address}_initTx_${initTx}_win1`
+- Issued reward asset/result id: `address_${address}_initTx_${initTx}_result`
+- Second issued reward asset/result id when applicable: `address_${address}_initTx_${initTx}_result1`
+- Random roll: `address_${address}_initTx_${initTx}_random`
+
+Status values:
+
+- `REBIRTH_STARTED`
+- `REBIRTH_FINISHED`
+
+The UI should store the init transaction id locally or derive active rebirths by querying dApp data keys for the connected address.
+
+## Rewards
+
+Random is based on the init tx id and finish block. Thresholds are out of 1000.
+
+- 10.0% `item!ART-FEED5`
+- 13.5% `item!ART-FEED10`
+- 10.5% `item!ART-FEED15`
+- 8.0% `item!ART-FEED20`
+- 6.0% `item!ART-FEED25`
+- 5.0% `bull_ranch_A`
+- 5.0% `bull_ranch_B`
+- 5.0% `bull_ranch_C`
+- 5.0% `bull_ranch_D`
+- 5.5% `duckling_10`
+- 3.5% `duckling_20`
+- 2.0% `duckling_40`
+- 3.0% `item!ART-KATANA`
+- 3.0% `item!ART-BUILTBODY`
+- 5.0% `item!ART-CANCPN`
+- 1.0% `item!ART-TOPHAT`
+- 1.0% `item!ART-ICECREAM`
+- 1.0% `item!ART-ORB`
+- 1.0% `item!ART-SCEPTER`
+- 1.0% `item!ART-SHOPBAG`
+- 0.7% `item!ART-FEED50`
+- 0.3% `item!ART-FEED100`
+- 0.4% `item!ART-POTION`
+- 0.4% `item!ART-ENEST`
+- 0.5% `item!ART-ROBODUCK`
+- 0.7% `bull_genesis`
+- 1.2% `item!ART-FIXGENE`
+- 0.8% `item!ART-FREEGENE`
+
+Reward result handling:
+
+- `item!CODE`: calls items `issueArtefactIndex(CODE, address, 0)`.
+- `bull_ranch_X`: calls bull farming `addFreePerch(address, X, 1)`.
+- `duckling_10`, `duckling_20`, `duckling_40`: calls baby ducks `issueFreeDuckling(address, initTx, level)`.
+- `bull_genesis`: calls bull incubator `issueFree(address, initTx)`.
+
+Double reward handling:
+
+- Item rewards issue two item NFTs with indexes `0` and `1`.
+- Ranch rewards add two free perches.
+- Duckling rewards issue one duckling with doubled level.
+- `bull_genesis` issues two free bulls, using `initTx` and the finish transaction id as separate entropy inputs.
+
+## Payment Split
+
+On `initRebirth`, the 999 TN payment is split in-contract:
+
+- 90% burned.
+- 1% sent to mutant farming through `topUpReward("TN", 0)`.
+- 9% transferred to `static_feeAggregator`.
+
+Both `initRebirth` and `finishRebirth` also require `static_extraFee` in WAVES.
+
+## Valid Bull Inputs
+
+The bull NFT may be issued by:
+
+- Bull incubator/rebirth dApp.
+- Bull breeder dApp.
+
+If the bull came from the breeder, rebirth invokes breeder `reduceRarity(assetId, gen)`.
+
+## Current PR
+
+GitHub PR: https://github.com/waves-ducks-core/wavesducks-public/pull/25
+
+Branch: `feature/TLK-1216-bull-rebirth`

--- a/jsonData/oracle-dev.json
+++ b/jsonData/oracle-dev.json
@@ -18,6 +18,11 @@
             "value": "3N6oB7VbceD3NoguGkfGnBMF4hcHZVbK8io"
         },
         {
+            "key": "static_bullIncubatorAddress",
+            "type": "string",
+            "value": "3N9osDS2cP1cT1NxJm7gb16Qusff5zHh5BF"
+        },
+        {
             "key": "static_rebirthAddress",
             "type": "string",
             "value": "3N6PvAL6whpaLE48xjeZbmU7vRWQmuz8AA5"

--- a/jsonData/oracle-prod.json
+++ b/jsonData/oracle-prod.json
@@ -18,6 +18,11 @@
             "value": "3PEktVux2RhchSN63DsDo4b4mz4QqzKSeDv"
         },
         {
+            "key": "static_bullIncubatorAddress",
+            "type": "string",
+            "value": "3PK5WcMpfQweLcxuuQ6F3w56PbeRTVn3Jjt"
+        },
+        {
             "key": "static_rebirthAddress",
             "type": "string",
             "value": "3PCC6fVHNa6289DTDmcUo3RuLaFmteZZsmQ"
@@ -278,4 +283,3 @@
     "senderPublicKey": "Ga8WEBTPXbHuoXRD355mQ6ms8PsM2RFYKeA1mEP32CFe"
 
 }
-

--- a/ride/artefacts/items.ride
+++ b/ride/artefacts/items.ride
@@ -18,6 +18,7 @@ func staticKey_duplicatorFee() = "static_duplicatorFee"
 func staticKey_canineRebirthAddress() = "static_canineRebirthAddress"
 func staticKey_eagleRebirthAddress() = "static_eagleRebirthAddress"
 func staticKey_felineRebirthAddress() = "static_felineRebirthAddress"
+func staticKey_bullIncubatorAddress() = "static_bullIncubatorAddress"
 func staticKey_babyDuckAddress() = "static_babyDuckAddress"
 func staticKey_burnAddress() = "static_burnAddress"
 func staticKey_mutantIncubatorAddress() = "static_mutantIncubatorAddress"
@@ -158,6 +159,7 @@ func getTurtleRebirthAddress() =  Address(tryGetStringExternal(getOracle(),stati
 func getCanineRebirthAddress() =  Address(tryGetStringExternal(getOracle(),staticKey_canineRebirthAddress()).fromBase58String())
 func getEagleRebirthAddress() =  Address(tryGetStringExternal(getOracle(),staticKey_eagleRebirthAddress()).fromBase58String())
 func getFelineeRebirthAddress() =  Address(tryGetStringExternal(getOracle(),staticKey_felineRebirthAddress()).fromBase58String())
+func getBullIncubatorAddress() =  Address(tryGetStringExternal(getOracle(),staticKey_bullIncubatorAddress()).fromBase58String())
 func getFeeAggregator() = Address(tryGetStringExternal(getOracle(),staticKey_feeAggregator()).fromBase58String())
 func getHuntDistroAddress() =  Address(tryGetStringExternal(getOracle(),staticKey_huntDistroAddress()).fromBase58String())
 func getWarsPKey() =  tryGetStringExternal(getOracle(),staticKey_warsPKey()).fromBase58String()
@@ -705,7 +707,7 @@ func issueArtefactIndex(type: String, receiver: String, nonce: Int) = {
   && i.caller != getTurtleBreederAddress()
   && i.caller != getCanineBreederAddress()
   && i.caller != getFelineBreederAddress() 
-  && i.caller != getCanineRebirthAddress() && i.caller != getFelineeRebirthAddress() && i.caller != getHuntDistroAddress()
+  && i.caller != getCanineRebirthAddress() && i.caller != getFelineeRebirthAddress() && i.caller != getBullIncubatorAddress() && i.caller != getHuntDistroAddress()
   && i.callerPublicKey != getWarsPKey()) then throw("IIAI: admin only") else 
      if ((i.caller == getHuntDistroAddress()|| i.callerPublicKey == getWarsPKey()) && !type.contains("ART-FIRE_") && !tryGetBoolean(type+"_issue") ) then throw("FIRE AND WHITELIST ITEM ONLY!") else
     let address = Address(fromBase58String(receiver))

--- a/ride/bulls/breeder.ride
+++ b/ride/bulls/breeder.ride
@@ -33,7 +33,6 @@ func staticKey_eggAssetId() = "static_eggAssetId"
 func staticKey_refContractAddress() = "static_refContractAddress"
 func staticKey_itemsAddress() = "static_itemsAddress"
 func staticKey_couponsAddress() = "static_couponsAddress"
-func staticKey_bullRebirthAddress() = "static_bullRebirthAddress"
 
 func getOracle() = Address(tryGetString(staticKey_oracleAddress()).fromBase58String())
 func getFeeAggregator() = Address(tryGetStringExternal(getOracle(),staticKey_feeAggregator()).fromBase58String())
@@ -44,7 +43,6 @@ func getBurnAddress() = Address(tryGetStringExternal(getOracle(),"static_burnAdd
 func getRefContractAddress() =  Address(tryGetStringExternal(getOracle(),staticKey_refContractAddress()).fromBase58String()) #base58'3P8ejTkfRpz9WqCwCuihesNXU5k3zmFFfVe'
 func getItemsAddress() = Address(tryGetStringExternal(getOracle(),staticKey_itemsAddress()).fromBase58String())
 func getCouponsAddress() = Address(tryGetStringExternal(getOracle(),staticKey_couponsAddress()).fromBase58String()) 
-func getBullRebirthAddress() = Address(tryGetStringExternal(getOracle(),staticKey_bullRebirthAddress()).fromBase58String())
 
 func checkAdditionalPayment(payment: AttachedPayment)= {
   if isDefined(payment.assetId) then throw("BDCAP: Please attach waves") else
@@ -246,7 +244,7 @@ func finishHatchingInternal(txIdStr: String, i: Invocation,
 @Callable(i)
 func reduceRarity(assetId: String, farmGen: String) = {
   let asset = assetId.fromBase58String()
-  if (i.caller != getBullRebirthAddress() && i.caller != this) then {
+  if (i.caller != getBullIncubator() && i.caller != this) then {
     throw("admin, items or rebirth only")
   } else {
     let duckGen = assetInfo(asset).value().name
@@ -260,7 +258,7 @@ func reduceRarity(assetId: String, farmGen: String) = {
 @Callable(i)
 func increaseRarity(assetId: String, farmGen: String) = {
   let asset = assetId.fromBase58String()
-  if (i.caller != getBullRebirthAddress() && i.caller != this) then {
+  if (i.caller != getBullIncubator() && i.caller != this) then {
     throw("admin, items or rebirth only")
   } else {
     let duckGen = assetInfo(asset).value().name

--- a/ride/bulls/farming.ride
+++ b/ride/bulls/farming.ride
@@ -45,7 +45,7 @@ func staticKey_extraFee() = "static_extraFee"
 func staticKey_feeAggregator() = "static_feeAggregator"
 let keyGlobalEarned = "global_earnings"
 func staticKey_perchFee() = "static_bullPerchFee"
-func staticKey_rebirthAddress() = "static_rebirthAddress"
+func staticKey_rebirthAddress() = "static_bullIncubatorAddress"
 func staticKey_itemsAddress() = "static_itemsAddress"
 func totalStakedKey() = "total_staked"
 func staticKey_wearablesAddress() = "static_wearablesAddress"
@@ -417,4 +417,4 @@ func verify() = {
     match (tx) {
         case _ => signaturesCount >= 1
     }
-} 
+}

--- a/ride/bulls/incubator.ride
+++ b/ride/bulls/incubator.ride
@@ -26,25 +26,28 @@ func staticKey_oracleAddress() = "static_oracleAddress"
 func staticKey_extraFee() = "static_extraFee"
 func staticKey_feeAggregator() = "static_feeAggregator"
 func staticKey_refContractAddress() = "static_refContractAddress"
-func staticKey_rebirthAddress() = "static_bullRebirthAddress"
-func staticKey_farmingAddress() = "static_bullStakingAddress"
+func staticKey_farmingAddress() = "static_bullFarmingAddress"
 func staticKey_itemsAddress() = "static_itemsAddress"
 func staticKey_bullAssetId() = "static_bullAssetId"
 func staticKey_mutantAddress() = "static_mutantFarmingAddress"
 func staticKey_eagleRebirthAddress() = "static_eagleRebirthAddress"
+func staticKey_bullBreederAddress() = "static_bullBreederAddress"
+func staticKey_babyDuckAddress() = "static_babyDuckAddress"
+func staticKey_bullRebirthPrice() = "static_bullRebirthPrice"
 
 func getOracle() = Address(tryGetString(staticKey_oracleAddress()).fromBase58String())
 func getFeeAggregator() = Address(tryGetStringExternal(getOracle(),staticKey_feeAggregator()).fromBase58String())
 func getMintAssetId() = tryGetStringExternal(getOracle(), staticKey_bullAssetId()).fromBase58String()
 func getBurnAddress() = Address(tryGetStringExternal(getOracle(),"static_burnAddress").fromBase58String())
 func getRefContractAddress() =  Address(tryGetStringExternal(getOracle(),staticKey_refContractAddress()).fromBase58String())
-#TODO: ADAPT THIS
-func getRebirthAddress() = this #Address(tryGetStringExternal(getOracle(),staticKey_rebirthAddress()).fromBase58String())
-#TODO: ADAPT THIS
-#func getFarmingAddress() =  Address(tryGetStringExternal(getOracle(),staticKey_farmingAddress()).fromBase58String()) 
+func getRebirthAddress() = this
+func getFarmingAddress() =  Address(tryGetStringExternal(getOracle(),staticKey_farmingAddress()).fromBase58String())
 func getItemsAddress() =  Address(tryGetStringExternal(getOracle(),staticKey_itemsAddress()).fromBase58String())
 func getMutantFarmingAddress() = Address(tryGetStringExternal(getOracle(),staticKey_mutantAddress()).fromBase58String())
 func getEagleRebirthAddress() = Address(tryGetStringExternal(getOracle(),staticKey_eagleRebirthAddress()).fromBase58String())
+func getBullBreederAddress() = Address(tryGetStringExternal(getOracle(),staticKey_bullBreederAddress()).fromBase58String())
+func getBabyDuckAddress() = Address(tryGetStringExternal(getOracle(),staticKey_babyDuckAddress()).fromBase58String())
+func getBullRebirthPrice() = getIntegerValue(getOracle(),staticKey_bullRebirthPrice())
 
 func checkAdditionalPayment(payment: AttachedPayment)= {
   if isDefined(payment.assetId) then throw("BDCAP: Please attach waves") else
@@ -59,6 +62,8 @@ let delayForHatching = 2
 
 let HatchingStarted = "HATCHING_STARTED"
 let HatchingFinished = "HATCHING_FINISHED"
+let RebirthStarted = "REBIRTH_STARTED"
+let RebirthFinished = "REBIRTH_FINISHED"
 
 func isLocked() = {
   let masterAddress = Address(base58'3PEPftf2kWZDmAaWBjs6BUJa9957kiA2PkU')
@@ -151,6 +156,157 @@ func asBoolean(value: Any) = match value {
   case _ => throw("TI: wrong type, expected: Boolean")
 }
 
+func getIncubatorFarmGen(assetName: String) = {
+  let generation = assetName.takeRight(2).take(1)
+  if generation == "J" then "8W-J" else {
+    let letter = assetName.take(6).takeRight(1)
+    "8"+letter+"-G"
+  }
+}
+
+func getRebirthStatusKey(address: String, initTx: String) = {
+  "address_" + address + "_initTx_" + initTx + "_status"
+}
+
+func getRebirthFinishBlockKey(address: String, initTx: String) = {
+  "address_" + address + "_initTx_" + initTx + "_finishBlock"
+}
+
+func getRebirthAssetKey(address: String, initTx: String) = {
+  "address_" + address + "_initTx_" + initTx + "_assetId"
+}
+
+func checkRealBull(assetId: ByteVector) = {
+  let issuer = assetInfo(assetId).value().issuer
+  if (issuer == this || issuer == getBullBreederAddress()) then issuer else throw("BRB: invalid bull NFT")
+}
+
+func getRandomRebirthWin(tx: ByteVector, finishHeight: Int, blacklistCode: String) = {
+  let n = getRandomNumber(1000, tx, finishHeight, 0)
+  let result =
+  if (n < 100 && blacklistCode != "item!ART-FEED5") then "item!ART-FEED5" else
+  if (n < 235 && blacklistCode != "item!ART-FEED10") then "item!ART-FEED10" else
+  if (n < 340 && blacklistCode != "item!ART-FEED15") then "item!ART-FEED15" else
+  if (n < 420 && blacklistCode != "item!ART-FEED20") then "item!ART-FEED20" else
+  if (n < 480 && blacklistCode != "item!ART-FEED25") then "item!ART-FEED25" else
+  if (n < 530 && blacklistCode != "bull_ranch_A") then "bull_ranch_A" else
+  if (n < 580 && blacklistCode != "bull_ranch_B") then "bull_ranch_B" else
+  if (n < 630 && blacklistCode != "bull_ranch_C") then "bull_ranch_C" else
+  if (n < 680 && blacklistCode != "bull_ranch_D") then "bull_ranch_D" else
+  if (n < 735 && blacklistCode != "duckling_10") then "duckling_10" else
+  if (n < 770 && blacklistCode != "duckling_20") then "duckling_20" else
+  if (n < 790 && blacklistCode != "duckling_40") then "duckling_40" else
+  if (n < 820 && blacklistCode != "item!ART-KATANA") then "item!ART-KATANA" else
+  if (n < 850 && blacklistCode != "item!ART-BUILTBODY") then "item!ART-BUILTBODY" else
+  if (n < 900 && blacklistCode != "item!ART-CANCPN") then "item!ART-CANCPN" else
+  if (n < 910 && blacklistCode != "item!ART-TOPHAT") then "item!ART-TOPHAT" else
+  if (n < 920 && blacklistCode != "item!ART-ICECREAM") then "item!ART-ICECREAM" else
+  if (n < 930 && blacklistCode != "item!ART-ORB") then "item!ART-ORB" else
+  if (n < 940 && blacklistCode != "item!ART-SCEPTER") then "item!ART-SCEPTER" else
+  if (n < 950 && blacklistCode != "item!ART-SHOPBAG") then "item!ART-SHOPBAG" else
+  if (n < 957 && blacklistCode != "item!ART-FEED50") then "item!ART-FEED50" else
+  if (n < 960 && blacklistCode != "item!ART-FEED100") then "item!ART-FEED100" else
+  if (n < 964 && blacklistCode != "item!ART-POTION") then "item!ART-POTION" else
+  if (n < 968 && blacklistCode != "item!ART-ENEST") then "item!ART-ENEST" else
+  if (n < 973 && blacklistCode != "item!ART-ROBODUCK") then "item!ART-ROBODUCK" else
+  if (n < 980 && blacklistCode != "bull_genesis") then "bull_genesis" else
+  if (n < 992 && blacklistCode != "item!ART-FIXGENE") then "item!ART-FIXGENE" else
+  if (blacklistCode != "item!ART-FREEGENE") then "item!ART-FREEGENE" else
+  "item!ART-FEED5"
+  (n, result)
+}
+
+func getRandomRebirthReturn(tx: ByteVector, finishHeight: Int) = {
+  let n = getRandomNumber(2, tx, finishHeight, 1)
+  if n == 1 then true else false
+}
+
+func finishRebirthInternal(initTx: String, address: String, additionalPayment: AttachedPayment, double: Boolean, blacklistCode: String, rescue: Boolean, finishTx: String) = {
+  strict feeValidate = checkAdditionalPayment(additionalPayment)
+  let finishBlock = tryGetInteger(getRebirthFinishBlockKey(address, initTx))
+  let status = tryGetString(getRebirthStatusKey(address, initTx))
+
+  if (status != RebirthStarted) then throw("BRF: rebirth is finished or not open") else
+  if (height < finishBlock) then throw("BRF: you cannot finish rebirth yet") else {
+    let output = getRandomRebirthWin(initTx.fromBase58String(), finishBlock, blacklistCode)
+    let random = output._1
+    let win = output._2
+    let txId = initTx
+    let reward = if (win.indexOf("item!") != unit) then {
+      let item = win.drop(5)
+      if !double then {
+        strict first = invoke(getItemsAddress(), "issueArtefactIndex", [item, address, 0], [])
+        [StringEntry("address_" + address + "_initTx_" + initTx + "_result", first.exactAs[String])]
+      } else {
+        strict first = invoke(getItemsAddress(), "issueArtefactIndex", [item, address, 0], [])
+        strict second = invoke(getItemsAddress(), "issueArtefactIndex", [item, address, 1], [])
+        [
+          StringEntry("address_" + address + "_initTx_" + initTx + "_result", first.exactAs[String]),
+          StringEntry("address_" + address + "_initTx_" + initTx + "_result1", second.exactAs[String]),
+          StringEntry("address_" + address + "_initTx_" + initTx + "_win1", win)
+        ]
+      }
+    } else if (win.indexOf("bull_ranch_") != unit) then {
+      let color = win.takeRight(1)
+      let amount = if double then 2 else 1
+      strict first = invoke(getFarmingAddress(), "addFreePerch", [address, color, amount], [])
+      if !double then {
+        [StringEntry("address_" + address + "_initTx_" + initTx + "_result", first.exactAs[String])]
+      } else {
+        [
+          StringEntry("address_" + address + "_initTx_" + initTx + "_result", first.exactAs[String]),
+          StringEntry("address_" + address + "_initTx_" + initTx + "_result1", first.exactAs[String]),
+          StringEntry("address_" + address + "_initTx_" + initTx + "_win1", win)
+        ]
+      }
+    } else if (win.indexOf("duckling_") != unit) then {
+      let level = if win == "duckling_10" then 10 else if win == "duckling_20" then 20 else 40
+      let levelFinal = if double then 2 * level else level
+      strict first = invoke(getBabyDuckAddress(), "issueFreeDuckling", [address, txId, levelFinal], [])
+      [StringEntry("address_" + address + "_initTx_" + initTx + "_result", first.exactAs[String])]
+    } else if (win == "bull_genesis") then {
+      if !double then {
+        strict first = invoke(this, "issueFree", [address, txId], [])
+        [StringEntry("address_" + address + "_initTx_" + initTx + "_result", first.exactAs[String])]
+      } else {
+        strict first = invoke(this, "issueFree", [address, txId], [])
+        strict second = invoke(this, "issueFree", [address, finishTx], [])
+        [
+          StringEntry("address_" + address + "_initTx_" + initTx + "_result", first.exactAs[String]),
+          StringEntry("address_" + address + "_initTx_" + initTx + "_result1", second.exactAs[String]),
+          StringEntry("address_" + address + "_initTx_" + initTx + "_win1", win)
+        ]
+      }
+    } else {
+      throw("BRF: invalid reward")
+    }
+    let returnToSender = if rescue then getRandomRebirthReturn(initTx.fromBase58String(), finishBlock) else false
+    let returnPayload = if returnToSender then {
+      let assetId = tryGetString(getRebirthAssetKey(address, initTx)).fromBase58String()
+      let issuer = checkRealBull(assetId)
+      let assetName = assetInfo(assetId).value().name
+      let localIncrease = if issuer == this then {
+        let farmGen = getIncubatorFarmGen(assetName)
+        [
+          IntegerEntry(getStatsKey(assetName), tryGetInteger(getStatsKey(assetName)) + 1),
+          IntegerEntry("stats_"+farmGen+"_quantity", tryGetInteger("stats_"+farmGen+"_quantity") + 1)
+        ]
+      } else []
+      strict breederIncrease = if issuer == getBullBreederAddress() then {
+        strict gen = invoke(getBullBreederAddress(),"getGenFromName",[assetName],[]).exactAs[String]
+        invoke(getBullBreederAddress(), "increaseRarity", [assetId.toBase58String(), gen], [])
+      } else nil
+      localIncrease ++ [ScriptTransfer(address.addressFromStringValue(), 1, assetId)]
+    } else []
+    reward ++ [
+      StringEntry(getRebirthStatusKey(address, initTx), RebirthFinished),
+      StringEntry("address_" + address + "_initTx_" + initTx + "_win", win),
+      StringEntry("address_" + address + "_initTx_" + initTx + "_win1", win),
+      IntegerEntry("address_" + address + "_initTx_" + initTx + "_random", random)
+    ] ++ feeValidate ++ returnPayload
+  }
+}
+
 @Callable(i)
 func reduceRarity(assetId: String, fGen: String) = {
   let asset = assetId.fromBase58String()
@@ -158,8 +314,7 @@ func reduceRarity(assetId: String, fGen: String) = {
     throw("IRR: admin or rebirth only")
   } else {
     let duckGen = assetInfo(asset).value().name
-    let letter = duckGen.take(6).takeRight(1)
-    let farmGen = "8"+letter+"-G"
+    let farmGen = getIncubatorFarmGen(duckGen)
     [
       IntegerEntry(getStatsKey(duckGen), tryGetInteger(getStatsKey(duckGen)) - 1),
       IntegerEntry("stats_"+farmGen+"_quantity", tryGetInteger("stats_"+farmGen+"_quantity") - 1)
@@ -174,8 +329,7 @@ func increaseRarity(assetId: String, fGen: String) = {
     throw("IRR: admin or rebirth only")
   } else {
     let duckGen = assetInfo(asset).value().name
-    let letter = duckGen.take(6).takeRight(1)
-    let farmGen = "8"+letter+"-G"
+    let farmGen = getIncubatorFarmGen(duckGen)
     [
       IntegerEntry(getStatsKey(duckGen), tryGetInteger(getStatsKey(duckGen)) + 1),
       IntegerEntry("stats_"+farmGen+"_quantity", tryGetInteger("stats_"+farmGen+"_quantity") + 1)
@@ -360,6 +514,86 @@ func finishHatching(txIdStr: String) = {
     }
 }
 
+@Callable(i)
+func initRebirth() = {
+  if (size(i.payments) != 3) then throw("BRI: wrong amount of payments") else
+  let bullPayment = i.payments[0]
+  let tnPayment = i.payments[1]
+  strict feeValidate = checkAdditionalPayment(i.payments[2])
+  let assetId = bullPayment.assetId.value()
+  let issuer = checkRealBull(assetId)
+  let address = i.caller.toString()
+  let initTx = i.transactionId.toBase58String()
+
+  if (bullPayment.amount != 1) then throw("BRI: NFT is not attached") else
+  if (tnPayment.amount != getBullRebirthPrice() || tnPayment.assetId != getMintAssetId()) then throw("BRI: attach exactly 999 TN") else
+    let assetName = assetInfo(assetId).value().name
+    let localReduce = if issuer == this then {
+      let farmGen = getIncubatorFarmGen(assetName)
+      [
+        IntegerEntry(getStatsKey(assetName), tryGetInteger(getStatsKey(assetName)) - 1),
+        IntegerEntry("stats_"+farmGen+"_quantity", tryGetInteger("stats_"+farmGen+"_quantity") - 1)
+      ]
+    } else []
+    strict breederReduce = if issuer == getBullBreederAddress() then {
+      strict gen = invoke(getBullBreederAddress(),"getGenFromName",[assetName],[]).exactAs[String]
+      invoke(getBullBreederAddress(), "reduceRarity", [assetId.toBase58String(), gen], [])
+    } else nil
+    let burn = tnPayment.amount / 10 * 9
+    let mutants = tnPayment.amount / 100
+    let fee = tnPayment.amount - burn - mutants
+    strict topup = invoke(getMutantFarmingAddress(), "topUpReward", ["TN",0], [AttachedPayment(getMintAssetId(), mutants)])
+    [
+      IntegerEntry(getRebirthFinishBlockKey(address, initTx), height + delayForHatching),
+      StringEntry(getRebirthStatusKey(address, initTx), RebirthStarted),
+      StringEntry(getRebirthAssetKey(address, initTx), assetId.toBase58String()),
+      Burn(getMintAssetId(), burn),
+      ScriptTransfer(getFeeAggregator(), fee, getMintAssetId()),
+      IntegerEntry("rebirth_burned", tryGetInteger("rebirth_burned") + burn)
+    ] ++ localReduce ++ feeValidate
+}
+
+@Callable(i)
+func finishRebirth(initTx: String) = {
+  if (size(i.payments) != 1) then throw("BRF: wrong amount of payments") else
+  finishRebirthInternal(initTx, i.caller.toString(), i.payments[0], false, "", false, i.transactionId.toBase58String())
+}
+
+@Callable(i)
+func finishRebirthDouble(initTx: String) = {
+  if !(size(i.payments) == 2 && i.payments[0].amount == 1) then throw("BRD: Invalid payment") else
+  let assetId = i.payments[0].assetId.value()
+  strict boosterType = invoke(getItemsAddress(), "checkArtefactDetails", [assetId.toBase58String()], []).exactAs[String]
+  if boosterType == "ART-GIFT_DOUBL" then {
+    [Burn(assetId, 1)] ++
+    finishRebirthInternal(initTx, i.caller.toString(), i.payments[1], true, "", false, i.transactionId.toBase58String())
+  } else {
+    throw("BRD: Wrong item attached to double rewards")
+  }
+}
+
+@Callable(i)
+func finishRebirthItem(initTx: String, itemCode: String) = {
+  if (size(i.payments) == 2 && i.payments[0].amount == 1) then
+    let assetId = i.payments[0].assetId.value()
+    strict boosterType = invoke(getItemsAddress(), "checkArtefactDetails", [assetId.toBase58String()], []).exactAs[String]
+    if boosterType == "ART-HWERASE" then {
+      [Burn(assetId, 1)] ++
+      finishRebirthInternal(initTx, i.caller.toString(), i.payments[1], false, itemCode, false, i.transactionId.toBase58String())
+    } else if boosterType == "ART-HWRESCUE" then {
+      [Burn(assetId, 1)] ++
+      finishRebirthInternal(initTx, i.caller.toString(), i.payments[1], false, "", true, i.transactionId.toBase58String())
+    } else if boosterType == "ART-GIFT_DOUBL" then {
+      [Burn(assetId, 1)] ++
+      finishRebirthInternal(initTx, i.caller.toString(), i.payments[1], true, "", false, i.transactionId.toBase58String())
+    } else {
+      throw("BRI: Wrong item attached")
+    }
+  else if (size(i.payments) == 1) then
+    finishRebirthInternal(initTx, i.caller.toString(), i.payments[0], false, "", false, i.transactionId.toBase58String())
+  else throw("BRI: Invalid payments")
+}
+
 
 @Verifier(tx)
 func verify() = {
@@ -388,5 +622,3 @@ func verify() = {
         case _ => signaturesCount >= 1
     }
 }
-
-        

--- a/ride/bulls/oracle-dev.json
+++ b/ride/bulls/oracle-dev.json
@@ -17,15 +17,15 @@
             "type": "integer",
             "value": 20000000
         },
+        {
+            "key": "static_bullRebirthPrice",
+            "type": "integer",
+            "value": 99900000000
+        },
                 {
             "key": "static_bullPerchFee",
             "type": "integer",
             "value": 20000000
-        },
-        {
-            "key": "static_bullRebirthAddress",
-            "type": "string",
-            "value": ""
         },
         {
             "key": "static_bullFarmingAddress",
@@ -47,4 +47,3 @@
     "sender":"3MxZNnLG9EBcb4yExxNwcFq9vcyMb7DcGT9",
     "senderPublicKey":"H3uYiohWLstHgnUqG1XQaByKhHeNewGoeH16WNFFGFR4"
 }
-

--- a/ride/bulls/oracle.json
+++ b/ride/bulls/oracle.json
@@ -17,15 +17,15 @@
             "type": "integer",
             "value": 20000000
         },
+        {
+            "key": "static_bullRebirthPrice",
+            "type": "integer",
+            "value": 99900000000
+        },
                 {
             "key": "static_bullPerchFee",
             "type": "integer",
             "value": 20000000
-        },
-        {
-            "key": "static_bullRebirthAddress",
-            "type": "string",
-            "value": ""
         },
         {
             "key": "static_bullFarmingAddress",
@@ -45,4 +45,3 @@
     "fee": 700000,
     "feeAssetId": "WAVES"
 }
-

--- a/ride/ducks/babyDuck.ride
+++ b/ride/ducks/babyDuck.ride
@@ -50,6 +50,7 @@ func staticKey_turtleStakingAddress() = "static_turtleStakingAddress"
 func staticKey_mutantFarmingAddress() = "static_mutantFarmingAddress"
 func staticKey_canineRebirthAddress() = "static_canineRebirthAddress"
 func staticKey_felineRebirthAddress() = "static_felineRebirthAddress"
+func staticKey_bullIncubatorAddress() = "static_bullIncubatorAddress"
 
 func getOracle() = Address(tryGetString(staticKey_oracleAddress()).fromBase58String())
 func getDucklingPrice() = tryGetIntegerExternal(getOracle(),staticKey_ducklingPrice())
@@ -65,6 +66,7 @@ func getTurtleStakingAddress() =  Address(tryGetStringExternal(getOracle(),stati
 func getMutantFarmingAddress() =  Address(tryGetStringExternal(getOracle(),staticKey_mutantFarmingAddress()).fromBase58String()) #base58'3PEktVux2RhchSN63DsDo4b4mz4QqzKSeDv'
 func getCanineRebirthAddress() =  Address(tryGetStringExternal(getOracle(),staticKey_canineRebirthAddress()).fromBase58String()) #base58'3PEktVux2RhchSN63DsDo4b4mz4QqzKSeDv'
 func getFelineRebirthAddress() =  Address(tryGetStringExternal(getOracle(),staticKey_felineRebirthAddress()).fromBase58String()) #base58'3PEktVux2RhchSN63DsDo4b4mz4QqzKSeDv'
+func getBullIncubatorAddress() =  Address(tryGetStringExternal(getOracle(),staticKey_bullIncubatorAddress()).fromBase58String())
 
 let backendPubKey = getStringValue(getOracle(),staticKey_backendPubKey()).fromBase58String()
 
@@ -229,7 +231,7 @@ func buyDuckling(refererAddress: String)={
 func issueFreeDuckling(address: String, txIdStr: String, percentage: Int) = {
   if i.caller != this && i.caller != getRebirthAddress() &&
    i.caller != getCanineRebirthAddress() && i.caller != getFelineRebirthAddress() &&
-   i.caller != getCouponsAddress() then throw("BIFD: You can't issue free duckling") else
+   i.caller != getBullIncubatorAddress() && i.caller != getCouponsAddress() then throw("BIFD: You can't issue free duckling") else
   let asset = Issue("BABY-11111111-GZ", "", 1, 0, false, unit, height)
     let assetId = asset.calculateAssetId()
     ([
@@ -389,4 +391,4 @@ func verify() = {
     match (tx) {
         case _ => signaturesCount >= 1
     }
-} 
+}


### PR DESCRIPTION
## Summary
- Implements Bull Rebirth inside the bull incubator contract instead of adding a separate rebirth SC.
- Adds JSON-driven fixed rebirth price: `static_bullRebirthPrice = 99900000000` (999 TN) in bull oracle data.
- Uses `static_bullIncubatorAddress` as the single canonical address for bull incubator/rebirth authorization; removed the duplicate `static_bullRebirthAddress` key.
- Adds the latest reward table with 95% normal rewards and 5% good rewards, including Roboduck, can coupon, boosted baby duck chances, and fix/free gene in the good bucket.
- Authorizes the bull incubator rebirth flow to issue item rewards, free bull ranches, and free baby ducks through the existing contracts.

## Validation
- `./node_modules/.bin/surfboard run /tmp/compile-bull-rebirth.js --env=testnet`
- `jq . ride/bulls/oracle.json`
- `jq . ride/bulls/oracle-dev.json`
- `jq . jsonData/oracle-prod.json`
- `jq . jsonData/oracle-dev.json`
- `git diff --check -- ride/bulls/incubator.ride ride/bulls/breeder.ride ride/bulls/farming.ride ride/artefacts/items.ride ride/ducks/babyDuck.ride ride/bulls/oracle.json ride/bulls/oracle-dev.json jsonData/oracle-prod.json jsonData/oracle-dev.json`