### PR TITLE
TLK-1187: fix summer bonus random offset

### DIFF
--- a/ride/bulls/breeder.ride
+++ b/ride/bulls/breeder.ride
@@ -224,7 +224,7 @@ func finishHatchingInternal(txIdStr: String, i: Invocation,
 
       let amount = tryGetInteger(getStatsKey(Gen)) + 1
       let quantity = tryGetInteger("stats_"+farmGen+"_quantity")
-      let random = getRandomNumber(100, txId, processFinishHeight, 20)
+      let random = getRandomNumber(100, txId, processFinishHeight, 3)
       let bonusOutput = if random % 2 == 0 then {
         strict bonus = invoke(getItemsAddress(),"issueArtefactIndex",["ART-BBALL",i.caller.toString(),2],[])
         [

--- a/ride/bulls/incubator.ride
+++ b/ride/bulls/incubator.ride
@@ -312,7 +312,7 @@ func finishRebirthInternal(initTx: String, address: String, additionalPayment: A
       } else nil
       localIncrease ++ [ScriptTransfer(address.addressFromStringValue(), 1, assetId)]
     } else []
-    let bonusRandom = getRandomNumber(100, initTx.fromBase58String(), finishBlock, 20)
+    let bonusRandom = getRandomNumber(100, initTx.fromBase58String(), finishBlock, 3)
     let bonusOutput = if bonusRandom % 2 == 0 then {
       strict bonus = invoke(getItemsAddress(),"issueArtefactIndex",["ART-BBALL",address,2],[])
       [

--- a/ride/cani/rebirth.ride
+++ b/ride/cani/rebirth.ride
@@ -268,7 +268,7 @@ func finishRebirthInternal(initTx: String, address: String, additionalPayment: A
         [ScriptTransfer(address.addressFromStringValue(), 1, 
         assetId)] 
       else []
-      let bonusRandom = getRandomNumber(100, initTx.fromBase58String(), finishBlock, 20)
+      let bonusRandom = getRandomNumber(100, initTx.fromBase58String(), finishBlock, 3)
       let bonusOutput = if bonusRandom % 2 == 0 then {
         strict bonus = invoke(getItemsAddress(),"issueArtefactIndex",["ART-BBALL",address,2],[])
         [

--- a/ride/ducks/breeder.ride
+++ b/ride/ducks/breeder.ride
@@ -249,7 +249,7 @@ func finishDuckHatch(txIdStr: String, owner: String, duckGenesString: String) = 
         ScriptTransfer(addressFromStringValue(owner), 1, parent1Id.fromBase58String()),
         ScriptTransfer(addressFromStringValue(owner), 1, parent2Id.fromBase58String())
       ] else []
-      let random = getRandomNumber(100, txId, processFinishHeight, 20)
+      let random = getRandomNumber(100, txId, processFinishHeight, 3)
       let bonusOutput = if random % 2 == 0 then {
         strict bonus = invoke(getItemsAddress(),"issueArtefactIndex",["ART-BBALL",owner,2],[])
         [

--- a/ride/ducks/rebirth.ride
+++ b/ride/ducks/rebirth.ride
@@ -378,7 +378,7 @@ func finishRebirthInternal(initTx: String, address: String, additionalPayment: A
         strict call = invoke(issuer, "increaseRarity", [assetId.toBase58String(), gen], [])
         [ScriptTransfer(address.addressFromStringValue(), 1,assetId)] 
       else []
-      let bonusRandom = getRandomNumber(100, initTx.fromBase58String(), finishBlock, 20)
+      let bonusRandom = getRandomNumber(100, initTx.fromBase58String(), finishBlock, 3)
       let bonusOutput = if bonusRandom % 2 == 0 then {
         strict bonus = invoke(getItemsAddress(),"issueArtefactIndex",["ART-BBALL",address,2],[])
         [

--- a/ride/eagl/rebirth.ride
+++ b/ride/eagl/rebirth.ride
@@ -349,7 +349,7 @@ func finishRebirthInternal(initTx: String, address: String, additionalPayment: A
         [ScriptTransfer(address.addressFromStringValue(), 1, 
         assetId)] 
       else []
-      let bonusRandom = getRandomNumber(100, initTx.fromBase58String(), finishBlock, 20)
+      let bonusRandom = getRandomNumber(100, initTx.fromBase58String(), finishBlock, 3)
       let bonusOutput = if bonusRandom % 2 == 0 then {
         strict bonus = invoke(getItemsAddress(),"issueArtefactIndex",["ART-BBALL",address,2],[])
         [

--- a/ride/feli/rebirth.ride
+++ b/ride/feli/rebirth.ride
@@ -255,7 +255,7 @@ func finishRebirthInternal(initTx: String, address: String, additionalPayment: A
         [ScriptTransfer(address.addressFromStringValue(), 1, 
         assetId)] 
       else []
-      let bonusRandom = getRandomNumber(100, initTx.fromBase58String(), finishBlock, 20)
+      let bonusRandom = getRandomNumber(100, initTx.fromBase58String(), finishBlock, 3)
       let bonusOutput = if bonusRandom % 2 == 0 then {
         strict bonus = invoke(getItemsAddress(),"issueArtefactIndex",["ART-BBALL",address,2],[])
         [

--- a/ride/turtle/rebirth.ride
+++ b/ride/turtle/rebirth.ride
@@ -274,7 +274,7 @@ func finishRebirthInternal(initTx: String, address: String, additionalPayment: A
         [ScriptTransfer(address.addressFromStringValue(), 1, 
         assetId)] 
       else []
-      let bonusRandom = getRandomNumber(100, initTx.fromBase58String(), finishBlock, 20)
+      let bonusRandom = getRandomNumber(100, initTx.fromBase58String(), finishBlock, 3)
       let bonusOutput = if bonusRandom % 2 == 0 then {
         strict bonus = invoke(getItemsAddress(),"issueArtefactIndex",["ART-BBALL",address,2],[])
         [


### PR DESCRIPTION
## Summary
- fixes the summer beach-ball bonus random offset on rebirth/breeder flows
- keeps the new branch based directly on main2 with only the offset fix

## Root Cause
The bonus code used offset 20, but these random helpers multiply offsets by 8 before reading the hash, causing IndexOutOfBounds.

## Validation
- surfboard compile ride/ducks/rebirth.ride
- surfboard compile ride/cani/rebirth.ride
- surfboard compile ride/eagl/rebirth.ride
- surfboard compile ride/feli/rebirth.ride
- surfboard compile ride/turtle/rebirth.ride
- surfboard compile ride/ducks/breeder.ride
- surfboard compile ride/bulls/breeder.ride
- surfboard compile ride/bulls/incubator.ride