### PR TITLE
TLK-1187: fix duck rebirth eagle incubator invoke

### DIFF
--- a/ride/ducks/rebirth.ride
+++ b/ride/ducks/rebirth.ride
@@ -287,12 +287,12 @@ func finishRebirthInternal(initTx: String, address: String, additionalPayment: A
         result
       }else if (win == "incubator_eagle") then {
         strict result = if !double then 
-                            strict first = invoke(getEagleIncubatorAddress(), "issueFree", [address, txId], [])
+                            strict first = invoke(getEagleIncubatorAddress(), "issueFree", [address, txId, false], [])
                             [
                               StringEntry("address_" + address + "_initTx_" + initTx + "_result", first.exactAs[String])
                             ]
 			                  else
-                            strict first = invoke(getEagleIncubatorAddress(), "issueFree", [address, txId], [])
+                            strict first = invoke(getEagleIncubatorAddress(), "issueFree", [address, txId, false], [])
                             strict second = invoke(getIncubatorAddress(), "issueFreeDuck", [address, txId], [])
                             [
                               StringEntry("address_" + address + "_initTx_" + initTx + "_result", first.exactAs[String]),


### PR DESCRIPTION
## Summary
- fixes duck rebirth `incubator_eagle` rewards to call Eagle incubator `issueFree` with the required `isNormal` argument
- uses `false` to match the default/non-normal Eagle incubator reward path

## Root Cause
`ride/eagl/incubator.ride` now defines `issueFree(address, txIdStr, isNormal)`, but `ride/ducks/rebirth.ride` still passed only `[address, txId]` for the `incubator_eagle` reward.

## Validation
- verified no remaining two-arg `getEagleIncubatorAddress().issueFree` calls
- `surfboard compile ride/ducks/rebirth.ride`
